### PR TITLE
Create hook for local/server state syncing

### DIFF
--- a/packages/editor/src/hooks/useConfig.ts
+++ b/packages/editor/src/hooks/useConfig.ts
@@ -1,0 +1,9 @@
+import { putConfig } from "@app/api";
+import { getConfig } from "@common/api";
+import type { ResponseSiteConfig } from "@types";
+import useLocalState from "./useLocalState";
+
+const useConfig = () =>
+    useLocalState<ResponseSiteConfig>("config", getConfig, putConfig);
+
+export default useConfig;

--- a/packages/editor/src/hooks/useLocalState.ts
+++ b/packages/editor/src/hooks/useLocalState.ts
@@ -1,0 +1,74 @@
+import { useState } from "react";
+import {
+    MutationKey,
+    useQuery,
+    useMutation,
+    UseQueryResult,
+    UseMutationResult,
+    useQueryClient,
+} from "react-query";
+
+type LocalState<T extends object> = T & {
+    __modified?: boolean | undefined;
+};
+
+const localState: Map<MutationKey, LocalState<any>> = new Map();
+
+const useLocalState: <T extends object>(
+    key: MutationKey,
+    get: () => Promise<T>,
+    sync: (data: T) => Promise<T>
+) => {
+    state: UseQueryResult<LocalState<T>, any>;
+    update: (callback: (old: T | undefined) => T | undefined) => unknown;
+    sync: UseMutationResult<T, any, void>;
+} = <T extends object>(
+    key: MutationKey,
+    get: () => Promise<T>,
+    sync: (data: T) => Promise<T>
+) => {
+    const [, setDummy] = useState(0);
+
+    const queryClient = useQueryClient();
+    const mutation = useMutation(
+        key,
+        () => {
+            const data = localState.get(key) as LocalState<T> | undefined;
+            delete data?.__modified;
+
+            if (!data) {
+                return Promise.reject(Error(`No data at ${key} to sync`));
+            }
+
+            return sync(data as T);
+        },
+        {
+            onSuccess: (data: T) => {
+                queryClient.setQueryData(key, data);
+            },
+        }
+    );
+
+    const serverData = useQuery<T, any>(key, get);
+    const localData = localState.get(key) as LocalState<T> | undefined;
+
+    const data = localData?.__modified
+        ? { ...serverData, data: localData }
+        : serverData;
+
+    if (data.data) localState.set(key, data.data);
+
+    return {
+        state: data as UseQueryResult<LocalState<T>, any>,
+        update: (callback) => {
+            // @ts-ignore
+            const localData = callback(data.data) as LocalState<T>;
+            if (localData) localData.__modified = true;
+            localState.set(key, localData);
+            setDummy((dummy) => dummy + 1);
+        },
+        sync: mutation,
+    };
+};
+
+export default useLocalState;

--- a/packages/editor/src/hooks/usePageConfig.ts
+++ b/packages/editor/src/hooks/usePageConfig.ts
@@ -1,0 +1,13 @@
+import { putPage } from "@app/api";
+import { getPage } from "@common/api";
+import type { PageResponse } from "@types";
+import useLocalState from "./useLocalState";
+
+const usePageConfig = (page: string | undefined) =>
+    useLocalState<PageResponse>(
+        ["page", page],
+        () => getPage(page, new URLSearchParams()),
+        (config) => putPage(page, config)
+    );
+
+export default usePageConfig;

--- a/packages/server/src/controllers/config.ts
+++ b/packages/server/src/controllers/config.ts
@@ -30,7 +30,7 @@ export const put = async (req: Request, res: Response): Promise<void> => {
 
     writePlatformConfig(config)
 
-    res.status(200).send()
+    res.status(200).send(config)
   } catch (error) {
     console.log(error)
     res.sendStatus(500)

--- a/packages/server/src/controllers/pages.ts
+++ b/packages/server/src/controllers/pages.ts
@@ -45,7 +45,7 @@ export const put = async function (req: Request, res: Response): Promise<void> {
 
   await writeUIMetadata(page, config)
 
-  res.sendStatus(200)
+  res.sendStatus(200).send(config)
 }
 
 const parseComponentsData = async (req: Request, res: Response, components: UIComponent[]): Promise<UIComponentResponse[]> => {


### PR DESCRIPTION
Adds a new hook, useLocalState, and derivatives for the global and page configs.\
This hook saves the state locally while editing and can then sync the data to the server.